### PR TITLE
Intriger i klartext

### DIFF
--- a/admin/edit_person.php
+++ b/admin/edit_person.php
@@ -144,6 +144,13 @@ include 'navigation.php';
 			<textarea id="HealthComment" name="HealthComment" rows="4" cols="100" maxlength="60000"><?php echo htmlspecialchars($person->HealthComment); ?></textarea>
 			</td></tr>
 
+			<tr><td valign="top" class="header">Intriger i text<br>Behövs för att säkert få uppläsning av intriger för de som har svårare att läsa själva</td>
+			<td>
+    			<input type="radio" id="WantIntriguesInPlainText_yes" name="WantIntriguesInPlainText" value="1" <?php if ($person->wantIntriguesInPlainText()) echo 'checked="checked"'?> required> 
+    			<label for="WantIntriguesInPlainText_yes">Ja</label><br> 
+    			<input type="radio" id="WantIntriguesInPlainText_no" name="WantIntriguesInPlainText" value="0" <?php if (!$person->wantIntriguesInPlainText()) echo 'checked="checked"'?>> 
+    			<label for="WantIntriguesInPlainText_no">Nej</label>
+			</td></tr>
 
 
 			<tr><td valign="top" class="header">Annan information</td>

--- a/admin/view_person.php
+++ b/admin/view_person.php
@@ -33,6 +33,25 @@ include 'navigation.php';
 	<div class="content">
 		<h1><?php echo $person->Name;?>&nbsp;<a href='edit_person.php?id=<?php echo $person->Id;?>'><i class='fa-solid fa-pen'></i></a></h1>
 		<div>
+		<?php 
+		if ($current_larp->isIntriguesReleased()) {
+
+		        $param = date_format(new Datetime(),"suv");
+		        $res = "<form action='../common/contact_email.php'  method='post'>\n";
+		        $res .= "<input type=hidden name='sender' value='$sender'>";
+		        $res .= "<input type=hidden name='one_intrigue' value=$param>\n".
+		  		        "<input type=hidden name='personId' value=$person->Id>\n".
+		  		        "<button type='submit'>".
+		  		        "Skicka intrigerna igen till $person->Name".
+		  		        "</button>\n".
+		  		        "</form>\n";
+		        echo $res;
+		    
+		}
+		
+		
+		?>
+		
 		<table>
 			<tr><td valign="top" class="header">Personnummer</td><td><?php echo $person->SocialSecurityNumber;?>, <?php echo $person->getAgeAtLarp($current_larp) ?> år</td></tr>
 			<tr><td valign="top" class="header">Email</td><td><?php echo $person->Email." ".contactEmailIcon($person);?></td></tr>
@@ -128,6 +147,7 @@ include 'navigation.php';
 			
 			<tr><td valign="top" class="header">Boendehänsyn</td><td><?php echo $person->getFullHousingComment($current_larp);?></td></tr>
 			<tr><td valign="top" class="header">Hälsa</td><td><?php echo $person->HealthComment;?></td></tr>
+			<tr><td valign="top" class="header">Intriger i text</td><td><?php echo ja_nej($person->wantIntriguesInPlainText());?></td></tr>
 
 
 			<tr><td valign="top" class="header">Annan information</td><td><?php echo nl2br($person->OtherInformation);?></td></tr>

--- a/admin/view_person.php
+++ b/admin/view_person.php
@@ -38,7 +38,6 @@ include 'navigation.php';
 
 		        $param = date_format(new Datetime(),"suv");
 		        $res = "<form action='../common/contact_email.php'  method='post'>\n";
-		        $res .= "<input type=hidden name='sender' value='$sender'>";
 		        $res .= "<input type=hidden name='one_intrigue' value=$param>\n".
 		  		        "<input type=hidden name='personId' value=$person->Id>\n".
 		  		        "<button type='submit'>".

--- a/common/contact_email.php
+++ b/common/contact_email.php
@@ -43,6 +43,13 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
         $type="intrigues";
         $name = '';
         $subject = "Intrigutskick för $current_larp->Name";
+    } elseif (isset($_POST['ne_intrigue'])) {
+        $type="one_intrigue";
+        $personId = $_POST['personId'];
+        $person = Person::loadById($personId);
+        $name = $person->Name;
+        $email = $person->Email;
+        $subject = "Intrigutskick för $current_larp->Name";
     } elseif (isset($_POST['send_housing'])) {
         $type="housing";
         $name = '';
@@ -104,6 +111,10 @@ include $navigation;
 		        if ($campaign->is_kir()) echo "Det kommer ta några minuter att skicka till alla.<br>Det går iväg som mest ett mail var 15 sekund.<br>\n";
 		        else echo "Eftersom karaktärsbladen är komplicerade att generera kommer de att skickas ut i omgångar för att inte belasta servern för mycket.<br>\n";
 		        echo "För att mailen ska gå iväg måste du fortsätta att använda systemet, eller låta sidan med skickad epost vara öppen.<br><br>\n";
+		        break;
+		    case "one_intrigue":
+		        echo "<h1>Skicka ut intrigerna till $name ($email).</h1>\n";
+		        echo "I mailet kommer karaktärsbladen till alla deras karaktärer och grupper som de är med i bifogas.<br>\n";
 		        break;
 		    case "housing":
 		        echo "<h1>Skicka ut boendet till alla deltagarna.</h1>\n";

--- a/common/contact_email.php
+++ b/common/contact_email.php
@@ -37,13 +37,14 @@ global $current_larp;
 $name = '';
 $type = "one";
 
+
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
     
     if (isset($_POST['send_intrigues'])) {
         $type="intrigues";
         $name = '';
         $subject = "Intrigutskick för $current_larp->Name";
-    } elseif (isset($_POST['ne_intrigue'])) {
+    } elseif (isset($_POST['one_intrigue'])) {
         $type="one_intrigue";
         $personId = $_POST['personId'];
         $person = Person::loadById($personId);

--- a/common/logic/send_contact_email.php
+++ b/common/logic/send_contact_email.php
@@ -47,6 +47,11 @@ switch ($type) {
         }
         BerghemMailer::sendIntrigues($greeting, $subject, nl2br($_POST['text']), $senderText, $current_larp, $current_person->Id);
         break;
+    case "one_intrigue":
+        $person = Person::loadById($_POST['personId']);
+        $registration = $person->getRegistration($current_larp);
+        BerghemMailer::sendIntrigue($greeting, $subject, nl2br($_POST['text']), $senderText, $current_larp, $current_person->Id, $registration->Id);
+        break;
     case "housing":
         if (!$current_larp->isHousingReleased()) {
             $current_larp->DisplayHousing = 1;

--- a/includes/html_helpers.php
+++ b/includes/html_helpers.php
@@ -484,3 +484,60 @@ function emailIcon() {
     
     $lastes_email;
 }
+
+
+
+function participantPrintedIntrigue($number, $commonText, $commonTextHeader, $intrigueTextArr, $offTextArr, $whatHappenedTextArr, $alwaysPrintWhatHappened) {
+    $formattedText = "";
+    if (!empty($commonText)) {
+        $formattedText .= "<p>";
+        if (!empty($commonTextHeader)) {
+            $formattedText .= "<strong>".htmlspecialchars($commonTextHeader)."</strong><br>";
+        }
+        $formattedText .= nl2br(htmlspecialchars($commonText))."</p>";
+    }
+    
+    if (!empty($intrigueTextArr)) {
+        $tmpIntrigueTextArr = array();
+        foreach ($intrigueTextArr as $intrigueText) {
+            if (is_array($intrigueText)) {
+                $tmpIntrigueTextArr[] = "<strong>".htmlspecialchars($intrigueText[0])."</strong><br>".nl2br(htmlspecialchars($intrigueText[1]));
+            } else {
+                $tmpIntrigueTextArr[] = nl2br(htmlspecialchars($intrigueText));
+            }
+        }
+        $formattedText .= "<p>".join("<br><br>",$tmpIntrigueTextArr). "</p>";
+        
+        
+        
+    }
+    
+    if (!empty($offTextArr)) {
+        $tmpOffTextArr = array();
+        foreach ($offTextArr as $offText) {
+            $tmpOffTextArr[] = nl2br(htmlspecialchars($offText));
+        }
+        $formattedText .= "<p><strong>Off-information:</strong><br><i>".join("<br><br>",$tmpOffTextArr)."</i></p>";
+    }
+    
+    if (!empty($whatHappenedTextArr) || $alwaysPrintWhatHappened) {
+        $tmpWhatHappenedTextArr = array();
+        foreach ($whatHappenedTextArr as $whatHappenedText) {
+            if (is_array($whatHappenedText)) {
+                $tmpWhatHappenedTextArr[] = "<strong>".htmlspecialchars($whatHappenedText[0])."</strong><br>".nl2br(htmlspecialchars($whatHappenedText[1]))."<br><br>";
+            } else {
+                $tmpWhatHappenedTextArr[] = nl2br(htmlspecialchars($whatHappenedText));
+            }
+        }
+        $formattedText .= "<p><strong>Vad hände med det:</strong><br>";
+        if (!empty($tmpWhatHappenedTextArr)) $formattedText .= join("<br><br>",$tmpWhatHappenedTextArr);
+        else $formattedText .= "Inget rapporterat";
+        $formattedText .= "</p>";
+    }
+    
+    if (!empty($formattedText)) {
+        return "<h3>Intrig $number:</h3>".$formattedText;
+    }
+    
+}
+

--- a/participant/person_form.php
+++ b/participant/person_form.php
@@ -140,6 +140,15 @@
 			<textarea id="HealthComment" name="HealthComment" rows="4" cols="100" maxlength="60000"><?php echo htmlspecialchars($person->HealthComment); ?></textarea>
 			</div>
 
+			<div class='itemcontainer'>
+	       	<div class='itemname'><label for="WantIntriguesInPlainText">Intriger i text</label></div>
+			Intriger kommer att skickas i text, förrutom som pdf. Är bra om man behöver uppläsning av intrigerna.<br>
+			<input type="radio" id="WantIntriguesInPlainText_yes" name="WantIntriguesInPlainText" value="1" <?php if ($person->wantIntriguesInPlainText()) echo 'checked="checked"'?> required> 
+			<label for="WantIntriguesInPlainText_yes">Ja</label><br> 
+			<input type="radio" id="WantIntriguesInPlainText_no" name="WantIntriguesInPlainText" value="0" <?php if (!$person->wantIntriguesInPlainText()) echo 'checked="checked"'?>> 
+			<label for="WantIntriguesInPlainText_no">Nej</label>
+			</div>
+
 
 			<div class='subheader'>Lajvrelaterat</div>
 			

--- a/participant/view_person.php
+++ b/participant/view_person.php
@@ -63,6 +63,11 @@ include 'navigation.php';
 		</div>
 		
    		<div class='itemcontainer'>
+       	<div class='itemname'>Intriger i text</div>
+		<?php echo ja_nej($current_person->wantIntriguesInPlainText());?>
+		</div>
+		
+   		<div class='itemcontainer'>
        	<div class='itemname'>Övrig information</div>
 		<?php echo nl2br(htmlspecialchars($current_person->OtherInformation));?>
 		</div>

--- a/participant/view_role.php
+++ b/participant/view_role.php
@@ -61,59 +61,6 @@ if($isMob){
 $temp=0;
 
 
-function printIntrigue($number, $commonText, $commonTextHeader, $intrigueTextArr, $offTextArr, $whatHappenedTextArr, $alwaysPrintWhatHappened) {
-    $formattedText = "";
-    if (!empty($commonText)) {
-        $formattedText .= "<p>";
-        if (!empty($commonTextHeader)) {
-            $formattedText .= "<strong>".htmlspecialchars($commonTextHeader)."</strong><br>";
-        }
-        $formattedText .= nl2br(htmlspecialchars($commonText))."</p>";
-    }
-    
-    if (!empty($intrigueTextArr)) {
-        $tmpIntrigueTextArr = array();
-        foreach ($intrigueTextArr as $intrigueText) {
-            if (is_array($intrigueText)) {
-                $tmpIntrigueTextArr[] = "<strong>".htmlspecialchars($intrigueText[0])."</strong><br>".nl2br(htmlspecialchars($intrigueText[1]));
-            } else {
-                $tmpIntrigueTextArr[] = nl2br(htmlspecialchars($intrigueText));
-            } 
-        }
-        $formattedText .= "<p>".join("<br><br>",$tmpIntrigueTextArr). "</p>";
-
-    
-    
-    }
-    
-    if (!empty($offTextArr)) {
-        $tmpOffTextArr = array();
-        foreach ($offTextArr as $offText) {
-            $tmpOffTextArr[] = nl2br(htmlspecialchars($offText));
-        }
-        $formattedText .= "<p><strong>Off-information:</strong><br><i>".join("<br><br>",$tmpOffTextArr)."</i></p>";
-    }
-
-    if (!empty($whatHappenedTextArr) || $alwaysPrintWhatHappened) {
-        $tmpWhatHappenedTextArr = array();
-        foreach ($whatHappenedTextArr as $whatHappenedText) {
-            if (is_array($whatHappenedText)) {
-                $tmpWhatHappenedTextArr[] = "<strong>".htmlspecialchars($whatHappenedText[0])."</strong><br>".nl2br(htmlspecialchars($whatHappenedText[1]))."<br><br>";
-            } else {
-                $tmpWhatHappenedTextArr[] = nl2br(htmlspecialchars($whatHappenedText));
-            }
-        }
-        $formattedText .= "<p><strong>Vad hände med det:</strong><br>";
-        if (!empty($tmpWhatHappenedTextArr)) $formattedText .= join("<br><br>",$tmpWhatHappenedTextArr);
-        else $formattedText .= "Inget rapporterat";
-        $formattedText .= "</p>";
-    }
-    
-    if (!empty($formattedText)) {
-        echo "<h3>Intrig $number:</h3>".$formattedText;
-    }
-    
-}
 
 
 include 'navigation.php';
@@ -413,7 +360,7 @@ include 'navigation.php';
 		                $intrigue->findAllInfoForRoleInIntrigue($role, $subdivisions, $commonTextHeader, $intrigueTextArr, $offTextArr, $whatHappenedTextArr);
 		                
                        
-		                printIntrigue($intrigue->Number, $intrigue->CommonText, $commonTextHeader, $intrigueTextArr, $offTextArr, $whatHappenedTextArr, false);
+		                echo participantPrintedIntrigue($intrigue->Number, $intrigue->CommonText, $commonTextHeader, $intrigueTextArr, $offTextArr, $whatHappenedTextArr, false);
 		                
 		                
 		            }


### PR DESCRIPTION
Deltagare kan få intriger + rykten som text i sitt intrigutskick. Detta för att göra det lättare för de som använder skärmläsare.